### PR TITLE
F11 toggle the editor fullscreen

### DIFF
--- a/kilink/static/css/style.css
+++ b/kilink/static/css/style.css
@@ -7,6 +7,16 @@
     margin-bottom: 1em;
 }
 
+.CodeMirror-fullscreen {
+    display: block !important;
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    z-index: 9999 !important;
+}
+
 .link {
     fill: none;
     stroke: #3DA4EE;

--- a/kilink/static/editor.js
+++ b/kilink/static/editor.js
@@ -1,7 +1,41 @@
+function isFullScreen(cm) {
+  return /\bCodeMirror-fullscreen\b/.test(cm.getWrapperElement().className);
+}
+function winHeight() {
+  return window.innerHeight || (document.documentElement || document.body).clientHeight;
+}
+function setFullScreen(cm, full) {
+  var wrap = cm.getWrapperElement();
+  if (full) {
+    wrap.className += " CodeMirror-fullscreen";
+    wrap.style.height = winHeight() + "px";
+    document.documentElement.style.overflow = "hidden";
+  } else {
+    wrap.className = wrap.className.replace(" CodeMirror-fullscreen", "");
+    wrap.style.height = "";
+    document.documentElement.style.overflow = "";
+  }
+  cm.refresh();
+}
+
+CodeMirror.on(window, "resize", function() {
+  var showing = document.body.getElementsByClassName("CodeMirror-fullscreen")[0];
+  if (!showing) return;
+  showing.CodeMirror.getWrapperElement().style.height = winHeight() + "px";
+});
+
 var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
   lineNumbers: true,
   tabMode: "indent",
-  autofocus: true
+  autofocus: true,
+  extraKeys: {
+        "F11": function(cm) {
+          setFullScreen(cm, !isFullScreen(cm));
+        },
+        "Esc": function(cm) {
+          if (isFullScreen(cm)) setFullScreen(cm, false);
+        }
+  }
 });
 
 editor.setOption("theme", 'monokai');
@@ -20,7 +54,7 @@ window.onload = function () {
     autoDetection = 0;
     modeInput.value = bmode;
     editor.setOption("mode", bmode);
-    }  
+    }
   },1)
 }
 


### PR DESCRIPTION
`F11` expands the editor to 100% of the window, alla 'zen mode'. `F11` again or `Esc` to go back. 
`Ctrl+Enter` still works in fullscreen
