### PR TITLE
Fix #122

### DIFF
--- a/kilink/static/js/main.js
+++ b/kilink/static/js/main.js
@@ -209,6 +209,9 @@ var linkode = (function (){
      * @param  {string}
      */
     function load_linkode(content, text_type, timestamp){
+        //Reset the auto option.
+        $("#selectlang option[value^='auto']").text("auto")
+        $("#selectlang option[value^='auto']").val("auto")
         $("#selectlang").val(text_type);
         editor.selectMode();
         set_timestamp(timestamp);


### PR DESCRIPTION
If linkodes was loaded with "auto" type, the select shows "auto" and detects the language again.
New linkodes will save with the real type instead of "auto".