### PR TITLE
On demand js

### DIFF
--- a/kilink/static/js/main.js
+++ b/kilink/static/js/main.js
@@ -528,6 +528,7 @@ var editor = (function (){
     function init(opts){
         $modeInput = $("#selectlang");
         $backInput = $("#text_type");
+        scripts_ulrs = opts.scripts_urls;
 
         $editor = CodeMirror.fromTextArea(document.getElementById("code"), {
             theme: 'monokai',
@@ -564,8 +565,10 @@ var editor = (function (){
         if(language_editor_mode[mode]){
             editor_mode = language_editor_mode[mode];
         }
-        $editor.setOption("mode", editor_mode);
-        needIndent(mode);
+        getScript(scripts_ulrs[mode], function(){
+            $editor.setOption("mode", editor_mode);
+            needIndent(mode);
+        });
     }
 
     /**
@@ -650,11 +653,28 @@ var editor = (function (){
         return $modeInput.find('option[value="' + value + '"]:first');
     }
 
+    function getScript(url, callback){
+        if ($.inArray(url, loaded_scripts) < 0) {
+            loaded_scripts.push(url);
+            jQuery.ajax({
+                type: "GET",
+                url: url,
+                dataType: "script",
+                cache: true,
+                success: callback
+            });
+        }
+        else{
+            callback();
+        }
+    };
+
     var $editor;
     var $modeInput;
     var $backInput;
 
     var autoDetection = 1;
+    var scripts_ulrs;
     var language_editor_mode = {
         "c": "text/x-csrc",
         "c#": "text/x-csharp",
@@ -730,6 +750,8 @@ var editor = (function (){
         "xml": "xml",
         "yaml": "yaml",
     };
+
+    var loaded_scripts = new Array();
 
     var module = {
         init: init,

--- a/kilink/static/js/main.js
+++ b/kilink/static/js/main.js
@@ -528,7 +528,7 @@ var editor = (function (){
     function init(opts){
         $modeInput = $("#selectlang");
         $backInput = $("#text_type");
-        scripts_ulrs = opts.scripts_urls;
+        scripts_urls = opts.scripts_urls;
 
         $editor = CodeMirror.fromTextArea(document.getElementById("code"), {
             theme: 'monokai',
@@ -565,7 +565,7 @@ var editor = (function (){
         if(language_editor_mode[mode]){
             editor_mode = language_editor_mode[mode];
         }
-        getScript(scripts_ulrs[mode], function(){
+        getScript(scripts_urls[mode], function(){
             $editor.setOption("mode", editor_mode);
             needIndent(mode);
         });
@@ -674,7 +674,7 @@ var editor = (function (){
     var $backInput;
 
     var autoDetection = 1;
-    var scripts_ulrs;
+    var scripts_urls;
     var language_editor_mode = {
         "c": "text/x-csrc",
         "c#": "text/x-csharp",

--- a/kilink/templates/_new.html
+++ b/kilink/templates/_new.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "helpers.html" import text_options, languages%}
+{% from "helpers.html" import text_options, script_list%}
 {% block main %}
 
 <div class="col-md-12">
@@ -41,8 +41,13 @@
 <script src="{{ url_for('static', filename='lib/codemirror.min.js') }}"></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/main.js') }}"></script>
 
+<!-- Languages -->
+    {{ script_list() }}
+<!-- End Languages -->
 <script type="text/javascript">
-    editor.init({});
+    editor.init({
+        scripts_urls: scripts_urls
+    });
 </script>
 
 <link type="text/css" href="{{ url_for('static', filename='css/placeholder.css') }}" rel="stylesheet">
@@ -52,9 +57,6 @@
 <script type="text/javascript" src="{{ url_for('static', filename='addon/display/placeholder.js') }}"></script>
 <script src="{{ url_for('static', filename='lib/highlight.js/highlight.pack.js') }}"></script>
 
-<!-- Languages -->
-    {{ languages() }}
-<!-- End Languages -->
 
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/tooltipster.bundle.css') }}" rel="stylesheet">
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/noty.css') }}" rel="stylesheet">

--- a/kilink/templates/helpers.html
+++ b/kilink/templates/helpers.html
@@ -41,6 +41,48 @@
     <option value="yaml">YAML</option>
 {% endmacro %}
 
+{% macro script_list()%}
+<script type="text/javascript">
+    const scripts_urls = {
+        "c" : "{{ url_for('static', filename='mode/clike/clike.js') }}",
+        "c#" : "{{ url_for('static', filename='mode/clike/clike.js') }}",
+        "c++" : "{{ url_for('static', filename='mode/clike/clike.js') }}",
+        "clojure": "{{ url_for('static', filename='mode/clojure/clojure.js') }}",
+        "coffeescript": "{{ url_for('static', filename='mode/coffeescript/coffeescript.js') }}",
+        "css": "{{ url_for('static', filename='mode/css/css.js') }}",
+        "d": "{{ url_for('static', filename='mode/d/d.js') }}",
+        "diff": "{{ url_for('static', filename='mode/diff/diff.js') }}",
+        "erlang": "{{ url_for('static', filename='mode/erlang/erlang.js') }}",
+        "go": "{{ url_for('static', filename='mode/go/go.js') }}",
+        "groovy": "{{ url_for('static', filename='mode/groovy/groovy.js') }}",
+        "haskell": "{{ url_for('static', filename='mode/haskell/haskell.js') }}",
+        "html": "{{ url_for('static', filename='mode/htmlmixed/htmlmixed.js') }}",
+        "htmlmixed": "{{ url_for('static', filename='mode/htmlmixed/htmlmixed.js') }}",
+        "http": "{{ url_for('static', filename='mode/http/http.js') }}",
+        "java": "{{ url_for('static', filename='mode/clike/clike.js') }}",
+        "javascript": "{{ url_for('static', filename='mode/javascript/javascript.js') }}",
+        "json": "{{ url_for('static', filename='mode/javascript/javascript.js') }}",
+        "less": "{{ url_for('static', filename='mode/css/css.js') }}",
+        "lua": "{{ url_for('static', filename='mode/lua/lua.js') }}",
+        "markdown": "{{ url_for('static', filename='mode/markdown/markdown.js') }}",
+        "nginx": "{{ url_for('static', filename='mode/nginx/nginx.js') }}",
+        "perl": "{{ url_for('static', filename='mode/perl/perl.js') }}",
+        "php": "{{ url_for('static', filename='mode/php/php.js') }}",
+        "python": "{{ url_for('static', filename='mode/python/python.js') }}",
+        "r": "{{ url_for('static', filename='mode/r/r.js') }}",
+        "ruby": "{{ url_for('static', filename='mode/ruby/ruby.js') }}",
+        "scala": "{{ url_for('static', filename='mode/clike/clike.js') }}",
+        "shell": "{{ url_for('static', filename='mode/shell/shell.js') }}",
+        "smalltalk": "{{ url_for('static', filename='mode/smalltalk/smalltalk.js') }}",
+        "sql": "{{ url_for('static', filename='mode/sql/sql.js') }}",
+        "stex": "{{ url_for('static', filename='mode/stex/stex.js') }}",
+        "typescript": "{{ url_for('static', filename='mode/javascript/javascript.js') }}",
+        "vbscript": "{{ url_for('static', filename='mode/vbscript/vbscript.js') }}",
+        "xml": "{{ url_for('static', filename='mode/xml/xml.js') }}",
+        "yaml": "{{ url_for('static', filename='mode/yaml/yaml.js') }}"
+    }
+</script>
+{% endmacro %}
 
 {% macro languages() %}
     <script src='/static/mode/clike/clike.js'></script>
@@ -64,7 +106,6 @@
     <script src='/static/mode/python/python.js'></script>
     <script src='/static/mode/r/r.js'></script>
     <script src='/static/mode/ruby/ruby.js'></script>
-<!--     <script src='/static/mode/rust/rust.js'></script> -->
     <script src='/static/mode/shell/shell.js'></script>
     <script src='/static/mode/smalltalk/smalltalk.js'></script>
     <script src='/static/mode/sql/sql.js'></script>


### PR DESCRIPTION
Every time linkode is open, the browser get and load the (currently) 28 modes that the editor use.
With this change, linkode will only load the mode that needs on demand so the page can load faster in the first access

Hope you like!