### PR TITLE
Fix bug that make two request on load with plain text

### DIFF
--- a/kilink/static/js/main.js
+++ b/kilink/static/js/main.js
@@ -654,7 +654,7 @@ var editor = (function (){
     }
 
     function getScript(url, callback){
-        if ($.inArray(url, loaded_scripts) < 0) {
+        if (url && $.inArray(url, loaded_scripts) < 0) {
             loaded_scripts.push(url);
             jQuery.ajax({
                 type: "GET",


### PR DESCRIPTION
I found a bug in #130 when the mode "plain text" that result an empty url make a request.
Apparently, if you check if an undefined variable is in an array (empty in this case) the result is true. 
This should solve the bug
Sorry.