### PR TITLE
🐞 content vacío no actualizaba

### DIFF
--- a/kilink/static/js/main.js
+++ b/kilink/static/js/main.js
@@ -647,7 +647,7 @@ var editor = (function (){
     * Get or set the text in the editor
     */
     function val(new_val){
-        if (new_val){
+        if (typeof new_val === 'string'){
             $editor.setValue(new_val);
         }
         else {


### PR DESCRIPTION
### Explicación:
Si un nuevo klink vacía el contenido (es decir, genera un `content` con string "" vacío)   
entonces el `editor`  no actualiza el content vacío, dejando el mismo `content` que el klink anterior.

### Cómo replicarlo:
1. Abrir el sitio, crear un klink con "algo".
1. Borrar el "algo" dejando "".
1. Generar Nueva versión.
1. Navegar el arbol entre el nodo 1, y 2.

###  Importante:
Esto **no está testeado** ni nada.
Vi el bug, vi una posible solución, acá la mando.